### PR TITLE
Fixes #140: Footer Year Not Rendering Correctly

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -223,7 +223,7 @@ const Footer: React.FC<FooterProps> = ({ layoutStyle }) => {
 
         <div className="border-t border-gray-300 dark:border-gray-700 flex flex-col items-center justify-center gap-1 pt-2 mt-[-20px] text-sm text-center">
           <p>
-            &copy; {currentYear + 1} {BRAND_NAME}. All rights reserved.
+            &copy; {currentYear} {BRAND_NAME}. All rights reserved.
           </p>
           <p>Built with ❤️ by TechXNinjas Student Community.</p>
         </div>


### PR DESCRIPTION
Bug Description
The footer displays the incorrect year.
Steps to reproduce:
- Go to the homepage.
- Scroll down to the footer.
- Observe the year displayed.

Expected behavior:
The footer should show the current year (e.g., 2025).

Actual behavior:
The year is not rendered correctly.

Desktop
OS: Mac
Browser: Safari
Version: MacBook Air ''13

Additional Context
The bug was caused by incorrect logic for rendering the year in the footer.
Fixed by ensuring {currentYear} is used, which is set as [new Date().getFullYear()]