### PR TITLE
Users unable to go back from AuthModal on small mobile screens

### DIFF
--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -6,6 +6,7 @@ import ForgotPasswordForm from './ForgotPasswordForm';
 import { CloseIcon } from '../icons';
 import { AuthContext } from '../../contexts/AuthContext';
 import { AuthContextType } from '../../types';
+import { ArrowLeft } from 'lucide-react';
 
 
 type AuthView = 'login' | 'register' | 'forgotPassword';
@@ -60,7 +61,17 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialView = 'l
 
   return (
     <div className="modal-overlay" onClick={handleOverlayClick} role="dialog" aria-modal="true" aria-labelledby="auth-modal-title">
-      <div className="modal-content dark:bg-gray-800 relative">
+      <div className="modal-content dark:bg-gray-800 relative pt-12">
+        {/* Mobile Back Button */}
+        <div className="sticky top-0 left-0 z-20 w-full flex items-start bg-inherit block sm:hidden" style={{ minHeight: '0' }}>
+          <button
+            onClick={onClose}
+            className="p-2 text-brand-primary hover:text-brand-ninja-gold rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors ml-2 mt-2"
+            aria-label="Back"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </button>
+        </div>
         <button
           onClick={onClose}
           className="absolute top-3 right-3 p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"


### PR DESCRIPTION
Issue :- On small‑height mobile screens, the AuthModal (login/register/forgot password) had no Back button, leaving users stuck in the modal with no way to navigate back or close it.

Solution : - 
-Added a Back button that is always visible at the top of the modal.
-Ensured the Back button remains fixed at the top even when scrolling, making it accessible on all screen heights.
-Styled the button to match existing UI and avoid overlapping modal content.

User Impact:-
-Users can now safely exit or go back from the modal on small mobile screens.
-Improves navigation and prevents users from being trapped.

✅ Checklist
 -Back button works on all AuthModal states (login/register/forgot password)
-Tested on small mobile devices and larger screens
- No regression on tablet/desktop

https://github.com/user-attachments/assets/fb1bfd72-2cdd-4ee6-8ea4-d5a6bd885478



Closes #<issue-number-47> 
